### PR TITLE
Syntax highlighting in post windows

### DIFF
--- a/lua/tidal/init.lua
+++ b/lua/tidal/init.lua
@@ -34,7 +34,7 @@ local function setup_user_commands()
   end, { desc = "Launch Tidal Notification Buffer" })
   vim.api.nvim_create_user_command("SuperColliderNotification", function()
     if state.sclang then
-      state.sclang:showNotificationBuffer("supercollider")
+      state.sclang:showNotificationBuffer("sc_post")
     end
   end, { desc = "Launch Tidal Notification Buffer" })
   vim.api.nvim_create_user_command("TidalQuit", api.exit_tidal, { desc = "Quit Tidal instance" })

--- a/lua/tidal/init.lua
+++ b/lua/tidal/init.lua
@@ -69,7 +69,7 @@ local function setup_autocmds()
     end,
   })
 
-  vim.api.nvim_create_autocmd({ "Filetype" }, {
+  vim.api.nvim_create_autocmd({ "FileType" }, {
     group = "Tidal",
     pattern = { "supercollider" },
     callback = function()

--- a/lua/tidal/init.lua
+++ b/lua/tidal/init.lua
@@ -29,7 +29,7 @@ local function setup_user_commands()
   end, { desc = "Launch Tidal instance" })
   vim.api.nvim_create_user_command("TidalNotification", function()
     if state.ghci then
-      state.ghci:showNotificationBuffer("haskell")
+      state.ghci:showNotificationBuffer("tidal_post")
     end
   end, { desc = "Launch Tidal Notification Buffer" })
   vim.api.nvim_create_user_command("SuperColliderNotification", function()

--- a/lua/tidal/util/repl/repl.lua
+++ b/lua/tidal/util/repl/repl.lua
@@ -55,6 +55,9 @@ local function attach(pipe, label, buf)
       local complete, remainder = {}, ""
 
       if buf_acc:sub(-1) == "\n" then
+        if #lines > 0 and lines[#lines] == "" then
+          table.remove(lines)
+        end
         complete, buf_acc = lines, ""
       else
         remainder = table.remove(lines)

--- a/syntax/sc_post.vim
+++ b/syntax/sc_post.vim
@@ -1,0 +1,63 @@
+" Syntax highlighting for supercollider post window.
+"
+" Taken from scnvim, original work by Mads Kjeldgaard.
+"
+" Building on the work of Alex Norman, David Granström and Stephen Lumenta for
+" SuperCollider, SCVIM and SCNVIM.
+
+scriptencoding utf-8
+
+" Check if this syntax file has been loaded before
+if exists('b:current_syntax')
+	finish
+endif
+let b:current_syntax = 'sc_post'
+
+syn case match " Not case sensitive
+
+" Result of execution
+syn region result start=/^->/ end=/\n/
+
+" Using Log.quark
+syn match logger /^\[\w*\]/
+
+"""""""""""""""""""
+" Error and warning messages
+"""""""""""""""""""
+syn match errorCursor "\^\^"
+syn match errors /ERROR:.*$/
+syn match receiverError /RECEIVER:.*$/
+syn match fails /FAIL:.*$/
+syn match warns /WARNING:.*$/
+syn match exceptions /EXCEPTION:.*$/
+
+syn match errorblock /^ERROR:.*$/
+syn match receiverBlock /^RECEIVER:.*$/
+syn match protectedcallstack /^PROTECTED CALL STACK:.*$/
+syn match callstack /^CALL STACK:.*$/
+
+" unittests
+syn match unittestPass /^PASS:.*$/
+syn match unittestRunning /^RUNNING UNIT TEST.*$/
+
+"""""""""""""""""""
+" Linking
+"""""""""""""""""""
+
+hi def link errors ErrorMsg
+hi def link errorBlock ErrorMsg
+hi def link receiverError ErrorMsg
+hi def link exceptions ErrorMsg
+hi def link errorCursor Bold
+hi def link fails ErrorMsg
+hi def link syntaxErrorContent Underlined
+hi def link warns WarningMsg
+
+hi def link receiverBlock WarningMsg
+hi def link callstack WarningMsg
+hi def link protectedcallstack WarningMsg
+
+hi def link logger Bold
+hi def link unittestPass OkMsg
+
+hi def link result OkMsg

--- a/syntax/tidal_post.vim
+++ b/syntax/tidal_post.vim
@@ -11,7 +11,7 @@ let b:current_syntax = 'tidal_post'
 syn case match
 
 syn match superdirtwait /^Waiting for SuperDirt.*$/
-syn match superdirthandshake /^Connected to SuperDirt./
+syn match superdirthandshake /^Connected to SuperDirt\./
 
 syn match ghciError /error:/
 

--- a/syntax/tidal_post.vim
+++ b/syntax/tidal_post.vim
@@ -1,0 +1,21 @@
+" Syntax highlighting for tidal post window.
+
+scriptencoding utf-8
+
+if exists('b:current_syntax')
+  finish
+endif
+
+let b:current_syntax = 'tidal_post'
+
+syn case match
+
+syn match superdirtwait /^Waiting for SuperDirt.*$/
+syn match superdirthandshake /^Connected to SuperDirt./
+
+syn match ghciError /error:/
+
+hi def link superdirtwait WarningMsg
+hi def link superdirthandshake OkMsg
+
+hi def link ghciError ErrorMsg


### PR DESCRIPTION

This PR aims to bring custom syntax highlighting in both supercollider and tidal post windows, using vim syntax files.
Additionnaly it fixes duplicated new lines on stdout messages.

There was also a typo on the `FileType` autocommand for supercollider, not sure if it was actually causing any issues, but luaLS didn't like it.
