### PR TITLE
added a custom event for TidalLaunch

### DIFF
--- a/lua/tidal/api.lua
+++ b/lua/tidal/api.lua
@@ -31,6 +31,8 @@ function M.launch_tidal(args)
   end
   vim.api.nvim_set_current_win(current_win)
   state.launched = true
+
+  vim.api.nvim_exec_autocmds("User", { pattern = "TidalLaunch" })
 end
 
 function M.start_event_highlighting(args)


### PR DESCRIPTION
This PR executes a user autocommand from the launch tidal function so that users could trigger other events when it's run.

This could be used to automatically start SuperCollider, or any other action the use wishes to take on launching Tidal.