### PR TITLE
Fix: Pass start parameter in send_visual for event highlighting

### DIFF
--- a/lua/tidal/api.lua
+++ b/lua/tidal/api.lua
@@ -115,7 +115,7 @@ function M.send_visual()
     require("tidal.core.highlight").apply_highlight(visual.start, visual.finish)
     local repl = ft_to_repl()
     if repl then
-      repl.send_multiline(visual.lines)
+      repl.send_multiline(visual.lines, visual.start)
     end
   end
 end


### PR DESCRIPTION
The send_visual function was not passing the start parameter to send_multiline, which prevented markers from being created for event highlighting when sending visual selections. This fix ensures that visual selections get proper beat highlighting just like send_line does.