### PR TITLE
add proper buffer uris for ghci and sclang

### DIFF
--- a/lua/tidal/core/boot.lua
+++ b/lua/tidal/core/boot.lua
@@ -13,7 +13,7 @@ function M.tidal(opts, split)
   end
 
   state.ghci = Ghci:new({
-    name = "tidal",
+    name = "tidal-fast://ghci-output",
     cmd = opts.cmd,
     args = vim.list_extend({
       "-XOverloadedStrings",
@@ -36,7 +36,7 @@ function M.sclang(opts, split)
   end
 
   state.sclang = Sclang:new({
-    name = "sclang",
+    name = "tidal-fast://sclang-output",
     cmd = opts.cmd,
     args = vim.list_extend({
       "-i",


### PR DESCRIPTION
the lack of uri's was causing issues for TidalNotification when:
running nvim on a tidal file in another directory then running the commands below

```
:TidalLaunch
:TidalNotification
```

would result in nvim trying to open the directory repeatedly and failing to append lines to the buffer