### PR TITLE
Add support for remote Tidal backends

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,28 @@ cd /Applications/SuperCollider.app/Contents/MacOS
 ./sclang "$@"
 ```
 
+#### Remote backends
+
+Instead of spawning a new `ghci` process, tidal.nvim can connect to an existing
+Tidal process over a Unix socket. This is useful when running Tidal outside of
+Neovim, e.g. to allow multiple editors to connect to the same Tidal session.
+
+Set `boot.tidal.remote` in your config:
+
+```lua
+boot = {
+  tidal = {
+    remote = {
+      --- Path to the Unix domain socket exposed by the running ghci process
+      unix = "/tmp/tidal.sock",
+      --- Optional: override the starting event ID (important when using
+      --- multiple editors to prevent collisions)
+      eventIdBase = 0,
+    },
+  },
+},
+```
+
 ### Keymaps
 
 `tidal.nvim` provides five configurable keymaps in `.tidal` and `.scd` files,

--- a/lua/tidal/config.lua
+++ b/lua/tidal/config.lua
@@ -7,7 +7,7 @@ local M = {}
 
 --- Connect to an existing process instead of spawning one.
 --- Type created to allow for a potential TCP backend
----@alias TidalRemote { unix: string, oscPort?: integer, stylePort?: integer, eventIdBase?: integer }
+---@alias TidalRemote { unix: string, eventIdBase?: integer }
 
 ---@class TidalProcConfig
 ---@field cmd string

--- a/lua/tidal/config.lua
+++ b/lua/tidal/config.lua
@@ -5,11 +5,16 @@ local M = {}
 ---@field sclang TidalProcConfig
 ---@field split "v" | nil
 
+--- Connect to an existing process instead of spawning one.
+--- Type created to allow for a potential TCP backend
+---@alias TidalRemote { unix: string, oscPort?: integer, stylePort?: integer, eventIdBase?: integer }
+
 ---@class TidalProcConfig
 ---@field cmd string
 ---@field file string
 ---@field args table<string>
 ---@field enabled boolean
+---@field remote? TidalRemote
 
 ---@class TidalConfig
 local defaults = {
@@ -24,6 +29,7 @@ local defaults = {
       --- Tidal boot file path
       file = vim.api.nvim_get_runtime_file("bootfiles/BootTidal.hs", false)[1],
       enabled = true,
+      remote = nil,
       highlight = {
         type = "stdio",
         styles = {

--- a/lua/tidal/core/boot.lua
+++ b/lua/tidal/core/boot.lua
@@ -26,8 +26,6 @@ function M.tidal(opts, split)
   })
 
   if opts.remote then
-    opts.highlight.events.osc.port = opts.remote.oscPort or opts.highlight.events.osc.port
-    opts.highlight.styles.osc.port = opts.remote.stylePort or opts.highlight.styles.osc.port
     tokenizer.eventIdBase = opts.remote.eventIdBase or tokenizer.eventIdBase
     tokenizer.lastEventId = tokenizer.eventIdBase
     state.ghci = ghci:connect_remote(opts.remote)

--- a/lua/tidal/core/boot.lua
+++ b/lua/tidal/core/boot.lua
@@ -1,6 +1,7 @@
 local Ghci = require("tidal.repl.ghci")
 local Sclang = require("tidal.repl.sclang")
 local state = require("tidal.core.state")
+local tokenizer = require("tidal.highlighting.tokenizer")
 
 local M = {}
 
@@ -12,7 +13,7 @@ function M.tidal(opts, split)
     return
   end
 
-  state.ghci = Ghci:new({
+  local ghci = Ghci:new({
     name = "tidal-fast://ghci-output",
     cmd = opts.cmd,
     args = vim.list_extend({
@@ -22,9 +23,17 @@ function M.tidal(opts, split)
     on_exit = function(_code, _signal)
       state.ghci = nil
     end,
-  }):start({
-    split = split or "v",
   })
+
+  if opts.remote then
+    opts.highlight.events.osc.port = opts.remote.oscPort or opts.highlight.events.osc.port
+    opts.highlight.styles.osc.port = opts.remote.stylePort or opts.highlight.styles.osc.port
+    tokenizer.eventIdBase = opts.remote.eventIdBase or tokenizer.eventIdBase
+    tokenizer.lastEventId = tokenizer.eventIdBase
+    state.ghci = ghci:connect_remote(opts.remote)
+  else
+    state.ghci = ghci:start({ split = split or "v" })
+  end
 end
 
 ---Start an sclang instance

--- a/lua/tidal/highlighting/tokenizer.lua
+++ b/lua/tidal/highlighting/tokenizer.lua
@@ -3,7 +3,8 @@ local Tokenizer = {}
 local lineProcessor = require("tidal.highlighting.lineprocessor")
 local marker = require("tidal.highlighting.marker")
 
-Tokenizer.lastEventId = 0
+Tokenizer.eventIdBase = 0
+Tokenizer.lastEventId = Tokenizer.eventIdBase
 
 -- Public function to transform control patterns into deltaContext format
 -- @param line string: The input line to process

--- a/lua/tidal/repl/repl.lua
+++ b/lua/tidal/repl/repl.lua
@@ -175,7 +175,7 @@ function Repl:send(text, start)
 
       if line:match("^hush") ~= nil then
         marker.deleteAllMarkers()
-        tokenizer.lastEventId = 0
+        tokenizer.lastEventId = tokenizer.eventIdBase
 
         vim.api.nvim_exec_autocmds("User", { pattern = "TidalHush", modeline = false })
       end
@@ -217,6 +217,31 @@ function Repl:send_multiline(lines, start)
   return self:send_line(table.concat(lines, "\n"), start)
 end
 
+--- Connect to an existing remote ghci process
+--- @param remote TidalRemote
+--- @generic T
+--- @return T for method chaining
+function Repl:connect_remote(remote)
+  if not remote.unix then
+    vim.notify("[tidal] remote requires .unix", vim.log.levels.ERROR)
+    return self
+  end
+  self.stdin = uv.new_pipe(false)
+  self.stdin:connect(remote.unix, function(err)
+    if err then
+      vim.schedule(function()
+        vim.notify(("[tidal] failed to connect to %s: %s"):format(remote.unix, err), vim.log.levels.ERROR)
+      end)
+      return
+    end
+    self:attach(self.stdin, "io")
+    vim.schedule(function()
+      vim.notify(("[tidal] connected to %s"):format(remote.unix), vim.log.levels.INFO)
+    end)
+  end)
+  return self
+end
+
 --- Close the REPL
 --- @return self for method chaining
 function Repl:exit()
@@ -228,6 +253,11 @@ function Repl:exit()
     self.proc:kill("sigterm") -- or "sigkill"
     self.proc:close()
     vim.notify(string.format("[tidal] %s stopped", self.opts.cmd))
+  elseif self.stdin and not self.stdin:is_closing() then
+    -- in spawn mode self.stdin gets closed by start()'s on_exit
+    -- handler; in remote mode we have to handle it ourselves
+    self.stdin:close()
+    vim.notify("[tidal] disconnected from remote")
   end
 
   return self

--- a/tests/tidal/util/repl/repl_spec.lua
+++ b/tests/tidal/util/repl/repl_spec.lua
@@ -106,6 +106,7 @@ describe("Repl", function()
     -- Mock tokenizer & marker ------------------------------------------------
     --------------------------------------------------------------------------
     package.loaded["tidal.highlighting.tokenizer"] = {
+      eventIdBase = 0,
       lastEventId = 42,
       addMetadata = function(line, row)
         return string.format("%s@%d", line, row)


### PR DESCRIPTION
Allow communication with Tidal over a unix socket, with a design easily extensible to add other backends such as TCP. This allows for a multi-editor setup via a broker that manages the GHCi process.