### PR TITLE
Fix gitlab ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
           ${{ matrix.install-rg }}
           rg --version
       - name: Checkout plenary.nvim
-        uses: actions/checkout@6
+        uses: actions/checkout@v6
         with:
           repository: nvim-lua/plenary.nvim
           path: ../plenary.nvim

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,7 @@ jobs:
             install-rg: sudo apt-get update && sudo apt-get install -y ripgrep
 
     steps:
+      - uses: actions/checkout@v6
       - uses: rhysd/action-setup-vim@v1
         with:
           neovim: true
@@ -25,7 +26,12 @@ jobs:
           ${{ matrix.install-rg }}
           rg --version
           GIT_TERMINAL_PROMPT=0 git clone --depth 1 https://github.com/nvim-lua/plenary.nvim ../plenary.nvim
+      - name: Debug workspace
+        run: |
+          pwd
+          ls -la
+          ls -la Makefile
       - name: Run tests
         run: |
           nvim --version
-          make -f ${{ github.workspace }}/Makefile test
+          make test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,11 +24,7 @@ jobs:
         run: |
           ${{ matrix.install-rg }}
           rg --version
-      - name: Checkout plenary.nvim
-        uses: actions/checkout@v6
-        with:
-          repository: nvim-lua/plenary.nvim
-          path: ../plenary.nvim
+          GIT_TERMINAL_PROMPT=0 git clone --depth 1 https://github.com/nvim-lua/plenary.nvim ../plenary.nvim
       - name: Run tests
         run: |
           nvim --version

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,18 +17,15 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
-
       - uses: rhysd/action-setup-vim@v1
         with:
           neovim: true
           version: v0.12.2
-
       - name: Prepare
         run: |
           ${{ matrix.install-rg }}
           rg --version
           git clone --depth 1 https://github.com/neovim-lua/plenary.nvim ../plenary.nvim
-
       - name: Run tests
         run: |
           nvim --version

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,11 +26,6 @@ jobs:
           ${{ matrix.install-rg }}
           rg --version
           GIT_TERMINAL_PROMPT=0 git clone --depth 1 https://github.com/nvim-lua/plenary.nvim ../plenary.nvim
-      - name: Debug workspace
-        run: |
-          pwd
-          ls -la
-          ls -la Makefile
       - name: Run tests
         run: |
           nvim --version

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: rhysd/action-setup-vim@v1
         with:
           neovim: true
-          version: v0.12.2
+          version: stable 
       - name: Prepare
         run: |
           ${{ matrix.install-rg }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,4 +28,4 @@ jobs:
       - name: Run tests
         run: |
           nvim --version
-          make test
+          make -f ${{ github.workspace }}/Makefile test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,6 @@ jobs:
             install-rg: sudo apt-get update && sudo apt-get install -y ripgrep
 
     steps:
-      - uses: actions/checkout@v6
       - uses: rhysd/action-setup-vim@v1
         with:
           neovim: true
@@ -25,7 +24,11 @@ jobs:
         run: |
           ${{ matrix.install-rg }}
           rg --version
-          git clone --depth 1 https://github.com/neovim-lua/plenary.nvim ../plenary.nvim
+      - name: Checkout plenary.nvim
+        uses: actions/checkout@6
+        with:
+          repository: nvim-lua/plenary.nvim
+          path: ../plenary.nvim
       - name: Run tests
         run: |
           nvim --version


### PR DESCRIPTION
This will use the stable nvim version for the plenary unit tests instead of the nightly build.